### PR TITLE
Update alt text for SwipedIn logo in metadata

### DIFF
--- a/swiped-in/src/app/apply/layout.tsx
+++ b/swiped-in/src/app/apply/layout.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
         url: "/logo.svg",
         width: 1200,
         height: 630,
-        alt: "SwipedIn Logo",
+        alt: "SwipedIn Logo - Job Applications",
       },
     ],
   },


### PR DESCRIPTION
Changed the alt attribute for the SwipedIn logo in the metadata to 'SwipedIn Logo - Job Applications' for improved accessibility and context.